### PR TITLE
Keycloak crash loop backoff fix

### DIFF
--- a/roles/keycloak-postgresql-helm/tasks/main.yaml
+++ b/roles/keycloak-postgresql-helm/tasks/main.yaml
@@ -4,6 +4,10 @@
     api_version: v1
     kind: Namespace
     state: present
+    definition:
+      metadata:
+        labels:
+          istio-injection: enabled # https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/
 
 - name: add postgresql (bitnami) helm repo
   kubernetes.core.helm_repository:
@@ -41,8 +45,12 @@
         enablePostgresUser: true
         database: keycloak
       primary:
+        livenessProbe:
+          initialDelaySeconds: 60
         persistence:
           enabled: true
           existingClaim: keycloak-postgres-vol-pvc
+        podAnnotations:
+          sidecar.istio.io/inject: "false"
       volumePermissions:
         enabled: true


### PR DESCRIPTION
* Added Istio sidecar injection to the Postgresql Ansible installation file, but excluding sidecar injection from the Postgresql container (no HTTP front end needs to reach it, at this time)

* Unsure why the sidecar prevents the Postgresql pod from behaving, here are some thoughts: 1) https://www.reddit.com/r/devops/comments/tazdh1/postgres_pods_connection_refused_after_enable/ 2) https://www.reddit.com/r/devops/comments/tazdh1/postgres_pods_connection_refused_after_enable/ (latter link seems promising)